### PR TITLE
Multi-period compatibility for cta profile

### DIFF
--- a/CMAFPresentationValidation.php
+++ b/CMAFPresentationValidation.php
@@ -18,46 +18,46 @@ $caac_SwSetFound=0;
 $encryptedSwSetFound=0;
 
 function checkPresentation(){
-    global $session_dir, $progress_xml, $progress_report, $string_info,
+    global $session_dir, $progress_xml, $progress_report, $string_info, $current_period,
             $presentation_infofile, $selectionset_infofile, $alignedswitching_infofile;
     
     checkCMAFPresentation();
     checkSelectionSet();
     checkAlignedSwitchingSets();
     
-    if(file_exists($session_dir.'/'.$selectionset_infofile.'.txt')){
-        $selSetFile=file_get_contents($session_dir.'/'.$selectionset_infofile.'.txt');
+    if(file_exists($session_dir.'/Period'.$current_period.'/'.$selectionset_infofile.'.txt')){
+        $selSetFile=file_get_contents($session_dir.'/Period'.$current_period.'/'.$selectionset_infofile.'.txt');
         if(strpos($selSetFile, "CMAF check violated") == false){
-             $progress_xml->Results[0]->addChild('SelectionSet', 'noerror');
-             $tempr_string = str_replace(array('$Template$'), array($selectionset_infofile), $string_info); // this string shows a text file on HTML
-             file_put_contents($session_dir.'/'.$selectionset_infofile.'.html', $tempr_string); // Create html file containing log file result
+             $progress_xml->Results[0]->Period[$current_period]->addChild('SelectionSet', 'noerror');
+             $tempr_string = str_replace('$Template$', '/Period'.$current_period.'/'.$selectionset_infofile, $string_info); // this string shows a text file on HTML
+             file_put_contents($session_dir.'/Period'.$current_period.'/'.$selectionset_infofile.'.html', $tempr_string); // Create html file containing log file result
              $file_error[] = "noerror"; // no error found in text file
         }
         else{
-            $progress_xml->Results[0]->addChild('SelectionSet', 'error');
-            $tempr_string = str_replace(array('$Template$'), array($selectionset_infofile), $string_info); // this string shows a text file on HTML
-            file_put_contents($session_dir.'/'.$selectionset_infofile.'.html', $tempr_string); // Create html file containing log file result
-            $file_error[] = $session_dir.'/'.$selectionset_infofile.'.html'; // add error file location to array
+            $progress_xml->Results[0]->Period[$current_period]->addChild('SelectionSet', 'error');
+            $tempr_string = str_replace('$Template$', '/Period'.$current_period.'/'.$selectionset_infofile, $string_info); // this string shows a text file on HTML
+            file_put_contents($session_dir.'/Period'.$current_period.'/'.$selectionset_infofile.'.html', $tempr_string); // Create html file containing log file result
+            $file_error[] = $session_dir.'/Period'.$current_period.'/'.$selectionset_infofile.'.html'; // add error file location to array
         }
         $progress_xml->asXml(trim($session_dir . '/' . $progress_report));
-        print_console($session_dir.'/'.$selectionset_infofile.'.txt', "CMAF Selection Set Results");
+        print_console($session_dir.'/Period'.$current_period.'/'.$selectionset_infofile.'.txt', "Period " . ($current_period+1) . " CMAF Selection Set Results");
     }
-    if(file_exists($session_dir.'/'.$presentation_infofile.'.txt')){
-        $presentnFile=file_get_contents($session_dir.'/'.$presentation_infofile.'.txt');
+    if(file_exists($session_dir.'/Period'.$current_period.'/'.$presentation_infofile.'.txt')){
+        $presentnFile=file_get_contents($session_dir.'/Period'.$current_period.'/'.$presentation_infofile.'.txt');
         if(strpos($presentnFile, "CMAF check violated") == false){
-             $progress_xml->Results[0]->addChild('CMAFProfile', 'noerror');
-             $tempr_string = str_replace(array('$Template$'), array($presentation_infofile), $string_info); // this string shows a text file on HTML
-             file_put_contents($session_dir.'/'.$presentation_infofile.'.html', $tempr_string); // Create html file containing log file result
+             $progress_xml->Results[0]->Period[$current_period]->addChild('CMAFProfile', 'noerror');
+             $tempr_string = str_replace('$Template$', '/Period'.$current_period.'/'.$presentation_infofile, $string_info); // this string shows a text file on HTML
+             file_put_contents($session_dir.'/Period'.$current_period.'/'.$presentation_infofile.'.html', $tempr_string); // Create html file containing log file result
              $file_error[] = "noerror"; // no error found in text file
         }
         else{
-            $progress_xml->Results[0]->addChild('CMAFProfile', 'error');
-            $tempr_string = str_replace(array('$Template$'), array($presentation_infofile), $string_info); // this string shows a text file on HTML
-            file_put_contents($session_dir.'/'.$presentation_infofile.'.html', $tempr_string); // Create html file containing log file result
-            $file_error[] = $session_dir.'/'.$presentation_infofile.'.html'; // add error file location to array
+            $progress_xml->Results[0]->Period[$current_period]->addChild('CMAFProfile', 'error');
+            $tempr_string = str_replace('$Template$', '/Period'.$current_period.'/'.$presentation_infofile, $string_info); // this string shows a text file on HTML
+            file_put_contents($session_dir.'/Period'.$current_period.'/'.$presentation_infofile.'.html', $tempr_string); // Create html file containing log file result
+            $file_error[] = $session_dir.'/Period'.$current_period.'/'.$presentation_infofile.'.html'; // add error file location to array
         }
         $progress_xml->asXml(trim($session_dir . '/' . $progress_report));
-        print_console($session_dir.'/'.$presentation_infofile.'.txt', "CMAF Presentation Results");
+        print_console($session_dir.'/Period'.$current_period.'/'.$presentation_infofile.'.txt', "Period " . ($current_period+1) . " CMAF Presentation Results");
     }
     
     return $file_error;
@@ -82,7 +82,7 @@ function checkCMAFPresentation(){
     $videoFragDur=0;
     //$lang_count=0;
     
-    if(!($opfile = open_file($session_dir. '/' . $presentation_infofile . '.txt', 'w'))){
+    if(!($opfile = open_file($session_dir. '/Period' . $current_period . '/' . $presentation_infofile . '.txt', 'w'))){
         echo "Error opening/creating Presentation profile conformance check file: "."./Presentation_infofile.txt";
         return;
     }
@@ -93,7 +93,7 @@ function checkCMAFPresentation(){
         $Adapt = $adapts[$adapt_count];
         
         $adapt_dir = str_replace('$AS$', $adapt_count, $adaptation_set_template);
-        $loc = $session_dir . '/' . $adapt_dir.'/';
+        $loc = $session_dir . '/Period' . $current_period . '/' . $adapt_dir.'/';
         $filecount = 0;
         $files = glob($loc . "*.xml");
         if($files)
@@ -344,7 +344,7 @@ function checkSelectionSet(){
     $longFragDur=0;
     $firstEntryflag=1;
     $SwSetDurArray=array();
-    if(!($opfile = open_file($session_dir. '/' . $selectionset_infofile . '.txt', 'w'))){
+    if(!($opfile = open_file($session_dir. '/Period' . $current_period . '/' . $selectionset_infofile . '.txt', 'w'))){
         echo "Error opening/creating SelectionSet_infofile conformance check file: "."SelectionSet_infofile.txt";
         return;
     }
@@ -357,7 +357,7 @@ function checkSelectionSet(){
         $Adapt=$adapts[$adapt_count];
         
         $adapt_dir = str_replace('$AS$', $adapt_count, $adaptation_set_template);
-        $loc = $session_dir . '/' . $adapt_dir.'/';
+        $loc = $session_dir . '/Period' . $current_period . '/' . $adapt_dir.'/';
         $filecount = 0;
         $files = glob($loc . "*.xml");
         if($files)
@@ -438,7 +438,7 @@ function checkAlignedSwitchingSets(){
         }             
     }
     if(count($index)>=1){ // 0 means no Aligned SwSet, 2 or more is fine, 1 means error should be raised.
-        if(!($opfile = open_file($session_dir. '/' . $alignedswitching_infofile . '.txt', 'w'))){
+        if(!($opfile = open_file($session_dir. '/Period' . $current_period . '/' . $alignedswitching_infofile . '.txt', 'w'))){
             echo "Error opening/creating Aligned SwitchingSet conformance check file: "."./AlignedSwitchingSet_infofile.txt";
             return;
         }
@@ -447,7 +447,7 @@ function checkAlignedSwitchingSets(){
         return;
     
     if(count($index)>=2){
-        $loc1 = $session_dir . '/Adapt' . ($index[0]-1).'/'; // For this naming there is no automation yet, since this implementation has an assumption on ids
+        $loc1 = $session_dir . '/Period' . $current_period . '/Adapt' . ($index[0]-1).'/'; // For this naming there is no automation yet, since this implementation has an assumption on ids
         $filecount1 = 0;
         $files1 = glob($loc1. "*.xml");
         if($files1)
@@ -463,7 +463,7 @@ function checkAlignedSwitchingSets(){
                 $id = $adapts[$index[0]-1]['Representation'][$i]['id'];
                 
                 if($xml){
-                    $loc2 = $session_dir . '/Adapt' . ($index[1]-1).'/'; // For this naming there is no automation yet, since this implementation has an assumption on ids
+                    $loc2 = $session_dir . '/Period' . $current_period . '/Adapt' . ($index[1]-1).'/'; // For this naming there is no automation yet, since this implementation has an assumption on ids
                     $filecount2 = 0;
                     $files2 = glob($loc2. "*.xml");
                     if($files2)

--- a/CMAFSwitchingSetsValidation.php
+++ b/CMAFSwitchingSetsValidation.php
@@ -216,7 +216,7 @@ function checkMediaProfiles($xml, $xml_comp,$xml_handlerType,$xml_comp_handlerTy
 }
 
 function checkHeaders($opfile, $xml, $xml_comp, $id, $id_comp, $curr_adapt_dir, $index, $path){
-    global $session_dir, $current_adaptation_set, 
+    global $session_dir, $current_period, $current_adaptation_set, 
             $adaptation_set_template, $infofile_template;
     
     compare($xml, $xml_comp, $id, $id_comp, $curr_adapt_dir, $index, $path);
@@ -225,7 +225,7 @@ function checkHeaders($opfile, $xml, $xml_comp, $id, $id_comp, $curr_adapt_dir, 
     if(file_exists($path)){
         $infofile = str_replace('$Number$', $index, $infofile_template);
         $adapt_dir = str_replace('$AS$', $current_adaptation_set, $adaptation_set_template);
-        $info_str = file_get_contents($session_dir . '/' . $adapt_dir . '/' . $infofile);
+        $info_str = file_get_contents($session_dir . '/Period' . $current_period . '/' . $adapt_dir . '/' . $infofile);
 
         $first = true;
         $xml = get_DOM($path, 'compInfo');
@@ -447,10 +447,10 @@ function checkSwitchingSets(){
             $adaptation_set_template, $comparison_folder, $compinfo_file, $progress_xml, $progress_report;
     
     $adaptation_set = $mpd_features['Period'][$current_period]['AdaptationSet'][$current_adaptation_set];
-    $curr_adapt_dir = $session_dir . '/' . str_replace('$AS$', $current_adaptation_set, $adaptation_set_template);
+    $curr_adapt_dir = $session_dir . '/Period' . $current_period . '/' . str_replace('$AS$', $current_adaptation_set, $adaptation_set_template);
     
     $compinfo = str_replace('$AS$', $current_adaptation_set, $compinfo_file);
-    if(!($opfile = open_file($session_dir.'/'.$compinfo.'.txt', 'w'))){
+    if(!($opfile = open_file($session_dir.'/Period'.$current_period.'/'.$compinfo.'.txt', 'w'))){
         echo "Error opening/creating compared representations' conformance check file: ". $session_dir.'/'.$compinfo.'.txt';
         return;
     }
@@ -491,25 +491,25 @@ function checkSwitchingSets(){
     
     fclose($opfile);
     
-    if(file_exists($session_dir.'/'.$compinfo.'.txt')){
-        $searchfiles = file_get_contents($session_dir.'/'.$compinfo.'.txt');
+    if(file_exists($session_dir.'/Period'.$current_period.'/'.$compinfo.'.txt')){
+        $searchfiles = file_get_contents($session_dir.'/Period'.$current_period.'/'.$compinfo.'.txt');
         if(strpos($searchfiles, "Error") == false && strpos($searchfiles, "CMAF check violated") == false){
-            $progress_xml->Results[0]->Period[0]->Adaptation[$current_adaptation_set]->addChild('ComparedRepresentations', 'noerror');
+            $progress_xml->Results[0]->Period[$current_period]->Adaptation[$current_adaptation_set]->addChild('ComparedRepresentations', 'noerror');
             $file_error[] = "noerror"; // no error found in text file
         }
         else{
-            $progress_xml->Results[0]->Period[0]->Adaptation[$current_adaptation_set]->addChild('ComparedRepresentations', 'error');
-            $file_error[] = $session_dir.'/'.$compinfo.'.html'; // add error file location to array
+            $progress_xml->Results[0]->Period[$current_period]->Adaptation[$current_adaptation_set]->addChild('ComparedRepresentations', 'error');
+            $file_error[] = $session_dir.'/Period'.$current_period.'/'.$compinfo.'.html'; // add error file location to array
         }
-        $progress_xml->Results[0]->Period[0]->Adaptation[$current_adaptation_set]->ComparedRepresentations->addAttribute('url', str_replace($_SERVER['DOCUMENT_ROOT'], 'http://' . $_SERVER['SERVER_NAME'], $session_dir.'/'.$compinfo.'.txt'));
+        $progress_xml->Results[0]->Period[$current_period]->Adaptation[$current_adaptation_set]->ComparedRepresentations->addAttribute('url', str_replace($_SERVER['DOCUMENT_ROOT'], 'http://' . $_SERVER['SERVER_NAME'], $session_dir.'/Period'.$current_period.'/'.$compinfo.'.txt'));
         $progress_xml->asXml(trim($session_dir . '/' . $progress_report));
         
-        $temp_string = str_replace ('$Template$',$compinfo,$string_info);
-        file_put_contents($session_dir.'/'.$compinfo.'.html',$temp_string);
+        $temp_string = str_replace ('$Template$','/Period'.$current_period.'/'.$compinfo,$string_info);
+        file_put_contents($session_dir.'/Period'.$current_period.'/'.$compinfo.'.html',$temp_string);
     }
     
     err_file_op(2);
-    print_console($session_dir.'/'.$compinfo.'.txt', "CMAF Switching Set Results for AdaptationSet $current_adaptation_set");
+    print_console($session_dir.'/Period'.$current_period.'/'.$compinfo.'.txt', "Period " . ($current_period+1) . " Adaptation Set " . ($current_adaptation_set+1) . " CMAF Switching Set Results");
     
     return $file_error;
 }

--- a/CMAFTracksValidation.php
+++ b/CMAFTracksValidation.php
@@ -20,7 +20,7 @@ function checkCMAFTracks(){
     
     $adapt_dir = str_replace('$AS$', $current_adaptation_set, $adaptation_set_template);
     $rep_xml_dir = str_replace(array('$AS$', '$R$'), array($current_adaptation_set, $current_representation), $reprsentation_template);
-    $rep_xml = $session_dir . '/' . $adapt_dir . '/' . $rep_xml_dir . '.xml';
+    $rep_xml = $session_dir . '/Period' . $current_period . '/' . $adapt_dir . '/' . $rep_xml_dir . '.xml';
     
     if(file_exists($rep_xml)){
         $xml = get_DOM($rep_xml, 'atomlist');
@@ -29,7 +29,7 @@ function checkCMAFTracks(){
             return;
         
         $error_file = str_replace(array('$AS$', '$R$'), array($current_adaptation_set, $current_representation), $reprsentation_error_log_template);
-        if(!($opfile = open_file($session_dir.'/'.$error_file.'.txt', 'a'))){
+        if(!($opfile = open_file($session_dir.'/Period'.$current_period.'/'.$error_file.'.txt', 'a'))){
             echo 'Error opening/creating CMAF Tracks conformance check file: '.$session_dir.'/'.$error_file.'.txt';
             return;
         }
@@ -267,19 +267,19 @@ function checkCMAFTracks(){
     }
     
     ## For reporting
-    $search = file_get_contents($session_dir . '/' . $error_file . '.txt'); //Search for errors within log file
+    $search = file_get_contents($session_dir . '/Period' . $current_period . '/' . $error_file . '.txt'); //Search for errors within log file
     if (strpos($search, "Error") == false && strpos($search, "CMAF check violated") == false){
         if(strpos($search, "Warning") === false && strpos($search, "WARNING") === false){
-            $progress_xml->Results[0]->Period[0]->Adaptation[$current_adaptation_set]->Representation[$current_representation] = "noerror";
+            $progress_xml->Results[0]->Period[$current_period]->Adaptation[$current_adaptation_set]->Representation[$current_representation] = "noerror";
             $file_location[] = "noerror";
         }
         else{
-            $progress_xml->Results[0]->Period[0]->Adaptation[$current_adaptation_set]->Representation[$current_representation] = "warning";
+            $progress_xml->Results[0]->Period[$current_period]->Adaptation[$current_adaptation_set]->Representation[$current_representation] = "warning";
             $file_location[] = "warning";
         }
     }
     else{
-        $progress_xml->Results[0]->Period[0]->Adaptation[$current_adaptation_set]->Representation[$current_representation] = "error";
+        $progress_xml->Results[0]->Period[$current_period]->Adaptation[$current_adaptation_set]->Representation[$current_representation] = "error";
         $file_location[] = "error";
     }
     $progress_xml->asXml(trim($session_dir . '/' . $progress_report));

--- a/CTAWAVE/CTAWAVE_PresentationProfile.php
+++ b/CTAWAVE/CTAWAVE_PresentationProfile.php
@@ -18,40 +18,42 @@ function CTAPresentation()
     global $mpd_features,$session_dir,$CTApresentation_infofile,$current_period,$adaptation_set_template, $opfile, $string_info, $progress_xml, $progress_report;
     $opfile="";
 
-    if(!($opfile = open_file($session_dir. '/' . $CTApresentation_infofile . '.txt', 'w'))){
+    if(!($opfile = open_file($session_dir. '/Period' . $current_period . '/' . $CTApresentation_infofile . '.txt', 'w'))){
             echo "Error opening/creating Presentation profile conformance check file: "."./Presentation_infofile_ctawave.txt";
             return;
-        }
+    }
     $adapts = $mpd_features['Period'][$current_period]['AdaptationSet'];
     $result= CTACheckPresentation(sizeof($adapts), $session_dir, $adaptation_set_template, $opfile);
     fclose($opfile);
     
     $temp_string = str_replace(array('$Template$'),array($CTApresentation_infofile),$string_info);
-    file_put_contents($session_dir.'/'.$CTApresentation_infofile.'.html',$temp_string);
+    file_put_contents($session_dir.'/Period'.$current_period.'/'.$CTApresentation_infofile.'.html',$temp_string);
     
-    $searchfiles = file_get_contents($session_dir.'/'.$CTApresentation_infofile.'.txt');
+    $searchfiles = file_get_contents($session_dir.'/Period'.$current_period.'/'.$CTApresentation_infofile.'.txt');
     if(strpos($searchfiles, "CTAWAVE check violated") !== FALSE){
-        $progress_xml->Results[0]->addChild('CTAWAVEPresentation', 'error');
-        $file_error[] = $session_dir.'/'.$CTApresentation_infofile.'.html';
+        $progress_xml->Results[0]->Period[$current_period]->addChild('CTAWAVEPresentation', 'error');
+        $file_error[] = $session_dir.'/Period' .$current_period.'/'.$CTApresentation_infofile.'.html';
     }
     elseif(strpos($searchfiles, "Warning") !== FALSE || strpos($searchfiles, "WARNING") !== FALSE){
-        $progress_xml->Results[0]->addChild('CTAWAVEPresentation', 'warning');
-        $file_error[] = $session_dir.'/'.$CTApresentation_infofile.'.html';
+        $progress_xml->Results[0]->Period[$current_period]->addChild('CTAWAVEPresentation', 'warning');
+        $file_error[] = $session_dir.'/Period'.$current_period.'/'.$CTApresentation_infofile.'.html';
     }
     else{
-        $progress_xml->Results[0]->addChild('CTAWAVEPresentation', 'noerror');
+        $progress_xml->Results[0]->Period[$current_period]->addChild('CTAWAVEPresentation', 'noerror');
         $file_error[] = "noerror";
     }
     
-    $tempr_string = str_replace(array('$Template$'), array($CTApresentation_infofile), $string_info);
-    file_put_contents($session_dir.'/'.$CTApresentation_infofile.'.html', $tempr_string);
+    $tempr_string = str_replace('$Template$', '/Period'.$current_period.'/'.$CTApresentation_infofile, $string_info);
+    file_put_contents($session_dir.'/Period'.$current_period.'/'.$CTApresentation_infofile.'.html', $tempr_string);
     $progress_xml->asXml(trim($session_dir . '/' . $progress_report));
     
-    print_console($session_dir.'/'.$CTApresentation_infofile.'.txt', "CTA WAVE Presentation Results");
+    print_console($session_dir.'/Period'.$current_period.'/'.$CTApresentation_infofile.'.txt', "Period " . ($current_period+1) . " CTA WAVE Presentation Results");
 }
 
 function CTACheckPresentation($adapts_count,$session_dir,$adaptation_set_template,$opfile)
 {
+    global $current_period;
+    
     $cfhdVideoSwSetFound=0;$videoSelectionSetFound=0;
     $caacAudioSwSetFound=0;$audioSelectionSetFound=0;
     $im1tSubtitleSwSetFound=0;$subtitleSelectionSetFound=0;
@@ -63,7 +65,7 @@ function CTACheckPresentation($adapts_count,$session_dir,$adaptation_set_templat
         $SwSet_MP=array();    
         $EncTracks=array();
         $adapt_dir = str_replace('$AS$', $adapt_count, $adaptation_set_template);
-        $loc = $session_dir . '/' . $adapt_dir.'/';
+        $loc = $session_dir . '/Period' . $current_period . '/' . $adapt_dir.'/';
         $filecount = 0;
         $files = glob($loc . "*.xml");
         if($files)

--- a/CTAWAVE/CTAWAVE_SelectionSet.php
+++ b/CTAWAVE/CTAWAVE_SelectionSet.php
@@ -48,7 +48,7 @@ function CTASelectionSet()
     $opfile="";
     
     
-    if(!($opfile = open_file($session_dir. '/' . $CTAselectionset_infofile . '.txt', 'w'))){
+    if(!($opfile = open_file($session_dir. '/Period' . $current_period . '/' . $CTAselectionset_infofile . '.txt', 'w'))){
         echo "Error opening/creating Selection Set conformance check file: "."./SelectionSet_infofile_ctawave.txt";
         return;
     }
@@ -59,27 +59,27 @@ function CTASelectionSet()
     fclose($opfile);
     
     $temp_string = str_replace(array('$Template$'),array($CTAselectionset_infofile),$string_info);
-    file_put_contents($session_dir.'/'.$CTAselectionset_infofile.'.html',$temp_string);
+    file_put_contents($session_dir.'/Period'.$current_period.'/'.$CTAselectionset_infofile.'.html',$temp_string);
     
-    $searchfiles = file_get_contents($session_dir.'/'.$CTAselectionset_infofile.'.txt');
+    $searchfiles = file_get_contents($session_dir.'/Period'.$current_period.'/'.$CTAselectionset_infofile.'.txt');
     if(strpos($searchfiles, "CTAWAVE check violated") !== FALSE){
-        $progress_xml->Results[0]->addChild('CTAWAVESelectionSet', 'error');
-        $file_error[] = $session_dir.'/'.$CTAselectionset_infofile.'.html';
+        $progress_xml->Results[0]->Period[$current_period]->addChild('CTAWAVESelectionSet', 'error');
+        $file_error[] = $session_dir.'/Period'.$current_period.'/'.$CTAselectionset_infofile.'.html';
     }
     elseif(strpos($searchfiles, "Warning") !== FALSE || strpos($searchfiles, "WARNING") !== FALSE){
-        $progress_xml->Results[0]->addChild('CTAWAVESelectionSet', 'warning');
-        $file_error[] = $session_dir.'/'.$CTAselectionset_infofile.'.html';
+        $progress_xml->Results[0]->Period[$current_period]->addChild('CTAWAVESelectionSet', 'warning');
+        $file_error[] = $session_dir.'/Period'.$current_period.'/'.$CTAselectionset_infofile.'.html';
     }
     else{
-        $progress_xml->Results[0]->addChild('CTAWAVESelectionSet', 'noerror');
+        $progress_xml->Results[0]->Period[$current_period]->addChild('CTAWAVESelectionSet', 'noerror');
         $file_error[] = "noerror";
     }
     
-    $tempr_string = str_replace(array('$Template$'), array($CTAselectionset_infofile), $string_info);
-    file_put_contents($session_dir.'/'.$CTAselectionset_infofile.'.html', $tempr_string);
+    $tempr_string = str_replace('$Template$', '/Period'.$current_period.'/'.$CTAselectionset_infofile, $string_info);
+    file_put_contents($session_dir.'/Period'.$current_period.'/'.$CTAselectionset_infofile.'.html', $tempr_string);
     $progress_xml->asXml(trim($session_dir . '/' . $progress_report));
     
-    print_console($session_dir.'/'.$CTAselectionset_infofile.'.txt', "CTA WAVE Selection Set Results");
+    print_console($session_dir.'/Period'.$current_period.'/'.$CTAselectionset_infofile.'.txt', "Period " . ($current_period+1) . " CTA WAVE Selection Set Results");
 }
 
 function CTACheckSelectionSet($adapts_count,$session_dir,$adaptation_set_template,$opfile)
@@ -97,7 +97,7 @@ function CTACheckSelectionSet($adapts_count,$session_dir,$adaptation_set_templat
 
         $SwSet_MP=array();
         $adapt_dir = str_replace('$AS$', $adapt_count, $adaptation_set_template);
-        $loc = $session_dir . '/' . $adapt_dir.'/';
+        $loc = $session_dir. '/Period' .$current_period. '/'. $adapt_dir.'/';
         $filecount = 0;
         $files = glob($loc . "*.xml");
         if($files)


### PR DESCRIPTION
Normally, in our software we just process the first period in static MPD or the current period in dynamic MPD. In case CTA WAVE profile is enforced, then all the periods are processed. This is introduced for CTA cross-profile checks. This effort requires directory and file name changes within the whole software. This commit contains the corresponding changes in this submodule.